### PR TITLE
Fixing errors found with go-vet

### DIFF
--- a/mtflow.go
+++ b/mtflow.go
@@ -133,10 +133,10 @@ func executeCommand(
 				write(msg)
 			}
 		default:
-			log.Println("The modifier '%s' is not handled", modifier)
+			log.Printf("The modifier '%s' is not handled\n", modifier)
 		}
 	default:
-		log.Println("The command '%s' is not handled", cmd)
+		log.Printf("The command '%s' is not handled\n", cmd)
 	}
 }
 


### PR DESCRIPTION
These errors where found by 'go vet'

Println does not support formatters. The multiple arguments of Println actually get joined with a space together. 

Printf does the desired behavior. Unfortunately, log does not provide the convenient method such as log.Fprintln thus '\n' is required.