### PR TITLE
Handle timeouts, adding status mtflow command

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
+	"runtime"
 	"time"
 )
 
@@ -120,6 +122,16 @@ func handleCommand(command Command, resultChannel chan string) {
 			}
 		default:
 			log.Printf("The modifier '%s' is not handled\n", command.Target)
+		}
+	case CommandStatus:
+		switch command.Target {
+		case CommandTargetMtFlow:
+			log.Println("I will handle 'status mtflow' command")
+
+			// get some memory statistics
+			var memStats runtime.MemStats
+			runtime.ReadMemStats(&memStats)
+			resultChannel <- fmt.Sprintf("I am chugging along, thanks for asking.\n\n# of Goroutines: %v\n# of CPU: %v\nTotal Memory: %v", runtime.NumGoroutine(), runtime.NumCPU(), memStats.Alloc)
 		}
 	default:
 		log.Printf("The command '%+v' is not handled\n", command)

--- a/parse.go
+++ b/parse.go
@@ -51,6 +51,9 @@ const (
 
 	// CommandTargetPR is the PullRequestService target name
 	CommandTargetPR = iota
+
+	// CommandTargetMtFlow is this program :)
+	CommandTargetMtFlow = iota
 )
 
 func (commandTarget CommandTarget) String() string {
@@ -59,6 +62,8 @@ func (commandTarget CommandTarget) String() string {
 		return "none"
 	case CommandTargetPR:
 		return "pr"
+	case CommandTargetMtFlow:
+		return "mtflow"
 	default:
 		panic("CommandTarget switch not considering all cases!")
 	}
@@ -105,6 +110,8 @@ func ParseCommand(commandStr string) (*Command, error) {
 			// command targets
 		case "pr":
 			commandTarget = CommandTargetPR
+		case "mtflow":
+			commandTarget = CommandTargetMtFlow
 		default:
 			if len(part) > 1 && part[0] == '@' {
 				mentions = append(mentions, part)


### PR DESCRIPTION
- Timeouts are now set to 30 seconds for all commands
- added status mtflow command that prints # of cpu's, # of goroutines, and total allocated bytes.